### PR TITLE
fix: Use session file from repo instead of fresh logins

### DIFF
--- a/scripts/main/publishing/post_3_carousels.py
+++ b/scripts/main/publishing/post_3_carousels.py
@@ -48,7 +48,7 @@ class ThreeCarouselPoster:
         self.post_results = []
 
     def load_session_bypass(self) -> bool:
-        """Load Instagram session using smart client (loads session or creates fresh login)"""
+        """Load Instagram session using smart client (loads existing session only, no fresh login)"""
         try:
             logger.info("🔄 Loading Instagram session with smart client...")
 
@@ -58,7 +58,7 @@ class ThreeCarouselPoster:
                 password=os.getenv('INSTAGRAM_PASSWORD')
             )
 
-            self.client = session_manager.get_smart_client()
+            self.client = session_manager.get_client_bypass_validation()
 
             if self.client:
                 logger.info("✅ Session loaded successfully!")

--- a/scripts/main/publishing/post_bitcoin_story.py
+++ b/scripts/main/publishing/post_bitcoin_story.py
@@ -156,12 +156,12 @@ def post_bitcoin_story_to_instagram(image_path):
     # Initialize session manager
     session_mgr = InstagramSessionManager(session_file=str(SESSION_FILE))
 
-    # Get client (loads session or creates fresh login)
-    client = session_mgr.get_smart_client()
+    # Get client (loads existing session only, no fresh login)
+    client = session_mgr.get_client_bypass_validation()
 
     if not client:
-        print("❌ Failed to authenticate with Instagram")
-        print("💡 Check your INSTAGRAM_USERNAME and INSTAGRAM_PASSWORD environment variables")
+        print("❌ Failed to load Instagram session from data/instagram_session.json")
+        print("💡 Session file may be expired. Refresh it locally:\n   python scripts/auth/create_instagram_session.py")
         return
 
     # Upload story

--- a/scripts/main/publishing/post_carousel.py
+++ b/scripts/main/publishing/post_carousel.py
@@ -66,8 +66,8 @@ class CarouselPoster:
                 password=os.getenv('INSTAGRAM_PASSWORD')
             )
 
-            # Use smart client (loads session or creates fresh login)
-            self.client = session_manager.get_smart_client()
+            # Use smart client (loads existing session only, no fresh login)
+            self.client = session_manager.get_client_bypass_validation()
 
             if self.client:
                 logger.info("✅ Session loaded successfully!")

--- a/scripts/main/publishing/post_long_calls_story.py
+++ b/scripts/main/publishing/post_long_calls_story.py
@@ -175,12 +175,12 @@ def post_trading_story_to_instagram(image_path):
     # Initialize session manager
     session_mgr = InstagramSessionManager(session_file=str(SESSION_FILE))
 
-    # Get client (loads session or creates fresh login)
-    client = session_mgr.get_smart_client()
+    # Get client (loads existing session only, no fresh login)
+    client = session_mgr.get_client_bypass_validation()
 
     if not client:
-        print("❌ Failed to authenticate with Instagram")
-        print("💡 Check your INSTAGRAM_USERNAME and INSTAGRAM_PASSWORD environment variables")
+        print("❌ Failed to load Instagram session from data/instagram_session.json")
+        print("💡 Session file may be expired. Refresh it locally:\n   python scripts/auth/create_instagram_session.py")
         return
 
     # Upload story

--- a/scripts/main/publishing/post_mega_carousel.py
+++ b/scripts/main/publishing/post_mega_carousel.py
@@ -215,15 +215,18 @@ def post_to_instagram(slide_paths, caption):
             session_file="data/instagram_session.json"
         )
 
-        # Get Instagram client (loads session or creates fresh login)
-        client = session_mgr.get_smart_client()
+        # Get Instagram client (loads existing session only, no fresh login)
+        client = session_mgr.get_client_bypass_validation()
 
         if not client:
-            print("\n❌ Failed to authenticate with Instagram")
-            print("💡 Check your INSTAGRAM_USERNAME and INSTAGRAM_PASSWORD environment variables")
+            print("\n❌ Failed to load Instagram session from data/instagram_session.json")
+            print("💡 Session file may be expired. Refresh it locally:")
+            print("   python scripts/auth/create_instagram_session.py")
             return False
 
-        print(f"👤 Logged in as: {client.username}")
+        # Note: client.username may be None but client still works
+        username = getattr(client, 'username', 'session_user')
+        print(f"👤 Logged in as: {username}")
 
         # Validate images exist
         for img_path in slide_paths:

--- a/scripts/main/publishing/post_short_calls_story.py
+++ b/scripts/main/publishing/post_short_calls_story.py
@@ -175,12 +175,12 @@ def post_trading_story_to_instagram(image_path):
     # Initialize session manager
     session_mgr = InstagramSessionManager(session_file=str(SESSION_FILE))
 
-    # Get client (loads session or creates fresh login)
-    client = session_mgr.get_smart_client()
+    # Get client (loads existing session only, no fresh login)
+    client = session_mgr.get_client_bypass_validation()
 
     if not client:
-        print("❌ Failed to authenticate with Instagram")
-        print("💡 Check your INSTAGRAM_USERNAME and INSTAGRAM_PASSWORD environment variables")
+        print("❌ Failed to load Instagram session from data/instagram_session.json")
+        print("💡 Session file may be expired. Refresh it locally:\n   python scripts/auth/create_instagram_session.py")
         return
 
     # Upload story

--- a/scripts/main/publishing/post_story_teaser.py
+++ b/scripts/main/publishing/post_story_teaser.py
@@ -247,15 +247,17 @@ class StoryTeaserPoster:
                 session_file="data/instagram_session.json"
             )
 
-            # Get Instagram client (loads session or creates fresh login)
-            client = session_mgr.get_smart_client()
+            # Get Instagram client (loads existing session only, no fresh login)
+            client = session_mgr.get_client_bypass_validation()
 
             if not client:
-                print("\n❌ Failed to authenticate with Instagram")
-                print("💡 Check your INSTAGRAM_USERNAME and INSTAGRAM_PASSWORD environment variables")
+                print("\n❌ Failed to load Instagram session from data/instagram_session.json")
+                print("💡 Session file may be expired. Refresh it locally:\n   python scripts/auth/create_instagram_session.py")
                 return False
 
-            print(f"👤 Logged in as: {client.username}")
+            # Note: client.username may be None but client still works
+            username = getattr(client, 'username', 'session_user')
+            print(f"👤 Logged in as: {username}")
 
             # Post story
             print("🚀 Uploading story...")

--- a/scripts/main/publishing/post_trading_calls_stories.py
+++ b/scripts/main/publishing/post_trading_calls_stories.py
@@ -172,12 +172,12 @@ def post_trading_story_to_instagram(image_path, call_type):
     # Initialize session manager
     session_mgr = InstagramSessionManager(session_file=str(SESSION_FILE))
 
-    # Get client (loads session or creates fresh login)
-    client = session_mgr.get_smart_client()
+    # Get client (loads existing session only, no fresh login)
+    client = session_mgr.get_client_bypass_validation()
 
     if not client:
-        print("❌ Failed to authenticate with Instagram")
-        print("💡 Check your INSTAGRAM_USERNAME and INSTAGRAM_PASSWORD environment variables")
+        print("❌ Failed to load Instagram session from data/instagram_session.json")
+        print("💡 Session file may be expired. Refresh it locally:\n   python scripts/auth/create_instagram_session.py")
         return
 
     # Upload story


### PR DESCRIPTION
Switch all posting scripts from get_smart_client() back to get_client_bypass_validation() to prevent fresh Instagram logins on every workflow run.

Why this change:
- Session file (data/instagram_session.json) is now committed to repo
- get_smart_client() tries validation → fails → does fresh login
- get_client_bypass_validation() only loads session file → no fresh login
- Reduces Instagram block risk from daily IP changes

Changes:
- All 8 posting scripts now use get_client_bypass_validation()
- Added safe username handling (may be None but client still works)
- Updated error messages to indicate session refresh needed
- No more daily fresh logins in GitHub Actions

Benefits:
✅ Consistent device fingerprint (same session every run) ✅ No fresh logins unless session expires (30 days) ✅ Lower Instagram security alert risk
✅ Manual session refresh control (every ~30 days)

Session maintenance:
- Refresh locally: python scripts/auth/create_instagram_session.py
- Commit updated session file
- Session valid for 30 days